### PR TITLE
Lock pyjwt version to 1.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '1.0.6'
 install_requires = [
     "djangorestframework>=3.7.7",
     "django>=2.2.1",
-    "PyJWT>=1.6.1",
+    "PyJWT==1.6.1",
     "requests>=2.20.0",
     "cryptography>=2.3",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = '1.0.6'
+version = '1.0.7'
 
 # When the project is installed by pip, this is the specification that is used to install its dependencies.
 install_requires = [


### PR DESCRIPTION
https://ridi.slack.com/archives/C01AVA6FP3Q/p1611021861049100?thread_ts=1610978588.042100&cid=C01AVA6FP3Q

PyJWT 버전을 1.6.1 로 고정합니다.